### PR TITLE
[DD-3080]: Fixes for the misclassification of non-ground points

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -28,12 +28,15 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(PCL REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
 
 # ROS 2 node. gseg: Abbrev. of `g`round `seg`mentation
 add_library(gseg_component SHARED src/GroundSegmentationServer.cpp)
 target_compile_features(gseg_component PUBLIC cxx_std_20)
-target_include_directories(gseg_component PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(gseg_component ${PARENT_PROJECT_NAME}::${TARGET_NAME})
+target_include_directories(gseg_component PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${PCL_INCLUDE_DIRS})
+target_link_libraries(gseg_component ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${PCL_LIBRARIES})
 ament_target_dependencies(
   gseg_component
   rcutils
@@ -43,6 +46,8 @@ ament_target_dependencies(
   sensor_msgs
   geometry_msgs
   tf2_ros
+  pcl_conversions
+  pcl_ros
 )
 
 rclcpp_components_register_node(gseg_component PLUGIN "patchworkpp_ros::GroundSegmentationServer" EXECUTABLE patchworkpp_node)

--- a/ros/config/patchworkpp.param.yaml
+++ b/ros/config/patchworkpp.param.yaml
@@ -14,4 +14,6 @@
     min_range: 0.0  # min_range of ground estimation area
     uprightness_thr: 0.101
     # threshold of uprightness using in Ground Likelihood Estimation(GLE). Please refer paper for more information about GLE.
+    base_link_proximity_radius: 10.0  # radius of base_link proximity filter
+    max_ground_height: 0.5  # maximum allowed height of ground inside the base_link proximity filter
     verbose: True  # display verbose info

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -17,7 +17,8 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-
+	<depend>pcl_conversions</depend>
+	<depend>pcl_msgs</depend>
 
   <exec_depend>ros2launch</exec_depend>
 

--- a/ros/src/GroundSegmentationServer.cpp
+++ b/ros/src/GroundSegmentationServer.cpp
@@ -49,6 +49,11 @@ GroundSegmentationServer::GroundSegmentationServer(const rclcpp::NodeOptions &op
   // Construct the main Patchwork++ node
   Patchworkpp_ = std::make_unique<patchwork::PatchWorkpp>(params);
 
+  // Parameters for base link proximity filtering
+  sensor_height_              = params.sensor_height;
+  base_link_proximity_radius_ = declare_parameter<double>("base_link_proximity_radius", 10.0);
+  max_ground_height_          = declare_parameter<double>("max_ground_height", 1.0);
+
   // Initialize subscribers
   pointcloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
     "pointcloud_topic", rclcpp::SensorDataQoS(),
@@ -127,21 +132,80 @@ void GroundSegmentationServer::EstimateGround(const sensor_msgs::msg::PointCloud
   std_msgs::msg::Float32 processing_time;
   processing_time.data = elapsed_seconds.count();
   processing_time_publisher_->publish(processing_time);
+  // Reclassify the ground and nonground points
+  std::pair<sensor_msgs::msg::PointCloud2::SharedPtr, sensor_msgs::msg::PointCloud2::SharedPtr> reclassified_clouds = ReclassifyGroundPoints(ground_points, ground_intensities, nonground_points, nonground_intensities, msg->header);
   // Publish the clouds with intensity values
-  PublishClouds(ground_points, ground_intensities, nonground_points, nonground_intensities, msg->header);
+  PublishClouds(reclassified_clouds.first, reclassified_clouds.second);
 }
 
-void GroundSegmentationServer::PublishClouds(const Eigen::MatrixX3f &est_ground,
-                                             const std::vector<float> &ground_intensities,
-                                             const Eigen::MatrixX3f &est_nonground,
-                                             const std::vector<float> &nonground_intensities,
-                                             const std_msgs::msg::Header &header_msg) {
-
+std::pair<sensor_msgs::msg::PointCloud2::SharedPtr, sensor_msgs::msg::PointCloud2::SharedPtr>
+GroundSegmentationServer::ReclassifyGroundPoints(const Eigen::MatrixX3f &est_ground,
+                                                 const std::vector<float> &ground_intensities,
+                                                 const Eigen::MatrixX3f &est_nonground,
+                                                 const std::vector<float> &nonground_intensities,
+                                                 const std_msgs::msg::Header &header_msg) 
+{
   std_msgs::msg::Header header = header_msg;
   header.frame_id = base_frame_;
 
-  ground_publisher_->publish(std::move(patchworkpp_ros::utils::EigenMatToPointCloud2(est_ground, ground_intensities, header)));
-  nonground_publisher_->publish(std::move(patchworkpp_ros::utils::EigenMatToPointCloud2(est_nonground, nonground_intensities, header)));
+  // Convert Eigen matrices to PointCloud2 and then to PCL clouds
+  std::shared_ptr<pcl::PointCloud<pcl::PointXYZI>> ground_pcl = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  patchworkpp_ros::utils::EigenMatToPCL(est_ground, ground_intensities, *ground_pcl);
+
+  std::shared_ptr<pcl::PointCloud<pcl::PointXYZI>> nonground_pcl = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  patchworkpp_ros::utils::EigenMatToPCL(est_nonground, nonground_intensities, *nonground_pcl);
+
+  auto reclassified_ground_pcl = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  auto reclassified_nonground_pcl = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+
+  // Copy all nonground points to reclassified non-ground point cloud
+  *reclassified_nonground_pcl = *nonground_pcl;
+
+  // Use CropBox for filtering ground points based on proximity to the base link
+  pcl::CropBox<pcl::PointXYZI> base_link_proximity_filter;
+  base_link_proximity_filter.setMin(Eigen::Vector4f(-base_link_proximity_radius_, -base_link_proximity_radius_, -std::numeric_limits<float>::max(), 1.0));
+  base_link_proximity_filter.setMax(Eigen::Vector4f(base_link_proximity_radius_, base_link_proximity_radius_, std::numeric_limits<float>::max(), 1.0));
+  base_link_proximity_filter.setInputCloud(ground_pcl);
+
+  // Points outside the region
+  base_link_proximity_filter.setNegative(true);
+  auto outside_region_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  base_link_proximity_filter.filter(*outside_region_pointcloud);
+  *reclassified_ground_pcl += *outside_region_pointcloud;
+
+  // Points inside the region
+  base_link_proximity_filter.setNegative(false);
+  auto inside_region_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  base_link_proximity_filter.filter(*inside_region_pointcloud);
+
+  for (const auto &point : inside_region_pointcloud->points) 
+  {
+    if (point.z + sensor_height_ <= max_ground_height_) 
+    {
+      reclassified_ground_pcl->push_back(point);
+    } 
+    else 
+    {
+      reclassified_nonground_pcl->push_back(point);
+    }
+  }
+
+  // Convert reclassified PCL clouds to ROS PointCloud2 messages
+  auto reclassified_ground_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+  pcl::toROSMsg(*reclassified_ground_pcl, *reclassified_ground_msg);
+  reclassified_ground_msg->header = header;
+
+  auto reclassified_nonground_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+  pcl::toROSMsg(*reclassified_nonground_pcl, *reclassified_nonground_msg);
+  reclassified_nonground_msg->header = header;
+
+  return {reclassified_ground_msg, reclassified_nonground_msg};
+}
+
+void GroundSegmentationServer::PublishClouds(sensor_msgs::msg::PointCloud2::SharedPtr ground_msg, sensor_msgs::msg::PointCloud2::SharedPtr nonground_msg) {
+
+  ground_publisher_->publish(*ground_msg);
+  nonground_publisher_->publish(*nonground_msg);
 }
 
 }  // namespace patchworkpp_ros

--- a/ros/src/GroundSegmentationServer.hpp
+++ b/ros/src/GroundSegmentationServer.hpp
@@ -7,6 +7,7 @@
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <pcl/filters/extract_indices.h>
 
 // ROS 2
 #include <rclcpp/rclcpp.hpp>

--- a/ros/src/GroundSegmentationServer.hpp
+++ b/ros/src/GroundSegmentationServer.hpp
@@ -1,6 +1,13 @@
 // Patchwork++
 #include "patchwork/patchworkpp.h"
 
+// pcl
+#include <pcl/common/transforms.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl/pcl_base.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
 // ROS 2
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -20,12 +27,15 @@ class GroundSegmentationServer : public rclcpp::Node {
   /// Register new frame
   void EstimateGround(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
 
+  std::pair<sensor_msgs::msg::PointCloud2::SharedPtr, sensor_msgs::msg::PointCloud2::SharedPtr>
+  ReclassifyGroundPoints(const Eigen::MatrixX3f &est_ground, 
+                         const std::vector<float> &ground_intensities, 
+                         const Eigen::MatrixX3f &est_nonground, 
+                         const std::vector<float> &nonground_intensities, 
+                         const std_msgs::msg::Header &header_msg); 
+
   /// Stream the point clouds for visualization
-  void PublishClouds(const Eigen::MatrixX3f &est_ground,
-                     const std::vector<float> &ground_intensities,
-                     const Eigen::MatrixX3f &est_nonground,
-                     const std::vector<float> &nonground_intensities,
-                     const std_msgs::msg::Header &header_msg);
+  void PublishClouds(sensor_msgs::msg::PointCloud2::SharedPtr ground_msg, sensor_msgs::msg::PointCloud2::SharedPtr nonground_msg);
 
  private:
   /// Data subscribers.
@@ -44,6 +54,9 @@ class GroundSegmentationServer : public rclcpp::Node {
   std::unique_ptr<patchwork::PatchWorkpp> Patchworkpp_;
 
   std::string base_frame_{"base_link"};
+  double sensor_height_{1.0};
+  double base_link_proximity_radius_{10.0};
+  double max_ground_height_{1.0};
 };
 
 }  // namespace patchworkpp_ros

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -207,4 +207,18 @@ inline std::unique_ptr<PointCloud2> EigenMatToPointCloud2(const Eigen::MatrixX3f
   return msg;
 }
 
+inline void EigenMatToPCL(const Eigen::MatrixX3f &matrix, 
+                          const std::vector<float> &intensities, 
+                          pcl::PointCloud<pcl::PointXYZI> &cloud) {
+  cloud.clear();
+  for (int i = 0; i < matrix.rows(); ++i) {
+    pcl::PointXYZI point;
+    point.x = matrix(i, 0);
+    point.y = matrix(i, 1);
+    point.z = matrix(i, 2);
+    point.intensity = intensities[i];
+    cloud.push_back(point);
+  }
+}
+
 }  // namespace patchworkpp_ros::utils


### PR DESCRIPTION
The current patchwork fails when placed in close proximity to taller objects like cars or any flat surfaces close to the robot. The reason behind this is the non-availability of ground rings in the pointcloud. This will not allow ground points to exceed a certain threshold near the `base_link`.